### PR TITLE
Cw 4 use react router transitions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,11 @@
+{
+    "parser": "babel-eslint",
+    "env": {
+        "browser": true,
+        "node": true
+    },
+    "extends": "airbnb",
+    "rules": {
+      "react/jsx-filename-extension": [1, { "extensions": [".js"] }]
+    }
+}

--- a/package.json
+++ b/package.json
@@ -3,8 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "eslint": "^4.2.0",
+    "prop-types": "^15.5.10",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
+    "react-router-dom": "^4.1.2",
     "react-scripts": "1.0.10",
     "semantic-ui-react": "^0.71.1"
   },
@@ -13,5 +16,12 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
+  },
+  "devDependencies": {
+    "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.2",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-react": "^7.1.0"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,28 +1,59 @@
 import React, { Component } from 'react';
-import Projects from './Projects';
-import Project from './Project';
 import {
   BrowserRouter as Router,
   Route,
 } from 'react-router-dom';
+import $ from 'jquery'; // eslint-disable-line
+
+import Projects from './Projects';
+import Project from './Project';
+
 import './App.css';
 
+const apiKey = 'keyQBC5qtKpZy4cWf';
+const table = 'Labs Project Tracking Staging';
+const view = 'All Projects';
+const projectsUri = `https://api.airtable.com/v0/app1f3lv9mx7L5xnY/${table}?view=${view}&api_key=${apiKey}`;
 
 class App extends Component {
   constructor(props) {
-    super(props)
+    super(props);
 
     this.state = {
-      projects: []
-    }
+      projects: [],
+    };
+  }
+
+  componentDidMount() {
+    this.fetchProjectsData();
+  }
+
+  fetchProjectsData() {
+    return $.getJSON(projectsUri)
+      .then((response) => {
+        const projects = response.records.map(record => record.fields);
+        this.setState({ projects });
+      });
   }
 
   render() {
+    const { projects } = this.state;
     return (
       <Router>
-        <div className='App'>
-          <Route exact path='/' component={Projects} />
-          <Route path='/ideas/:id' component={Project} />
+        <div className="App">
+          <Route
+            exact
+            path="/"
+            render={() => (
+              <Projects projects={projects} />
+            )}
+          />
+          <Route
+            path="/ideas/:id"
+            render={props => (
+              <Project projects={projects} {...props} />
+            )}
+          />
         </div>
       </Router>
     );

--- a/src/Project.js
+++ b/src/Project.js
@@ -1,19 +1,31 @@
-import React, { Component } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
+
 import './Project.css';
 
-class Project extends Component {
-  constructor(props) {
-    super();
-    this.match = props.match;
-  }
+const Project = (props) => {
+  const id = parseInt(props.match.params.id, 10);
 
-  render() {
-    return (
-      <div className="project">
-      	{this.match.params.id}
-      </div>
-    );
-  }
-}
+  const idea = props.projects.find(d => d.project_id === id);
+
+  return (
+    <div className="project">
+      {idea &&
+        (
+          <div>{idea.project_name} - { idea.point_of_contact }</div>
+        )
+      }
+    </div>
+  );
+};
+
+Project.propTypes = {
+  projects: PropTypes.arrayOf(PropTypes.object).isRequired,
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      id: PropTypes.number,
+    }),
+  }).isRequired,
+};
 
 export default Project;

--- a/src/Projects.js
+++ b/src/Projects.js
@@ -1,71 +1,40 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { List, Icon } from 'semantic-ui-react';
-import { withRouter } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
-import $ from 'jquery';
 import './Projects.css';
 
-const api_key = 'keyQBC5qtKpZy4cWf';
-const table = 'Labs Project Tracking Staging';
-const view = 'All Projects';
-const projects_uri = `https://api.airtable.com/v0/app1f3lv9mx7L5xnY/${table}?view=${view}&api_key=${api_key}`;
-
 class Projects extends Component {
-  constructor(props) {
-    super(props)
-
-    this.state = {
-      projects: []
-    }
-  }
-
-  componentDidMount() {
-    this.fetchProjectsData();
-  }
-
-  fetchProjectsData() {
-    return $.getJSON(projects_uri)
-      .then((response) => {
-        let projects = response.records.map((record) => { return record.fields; });
-        this.setState({
-          projects
-        });
-      });
-  }
-
-  linkTo() {
-    withRouter(({ history }) => {
-      return history.push('/ideas/1');
-    });
-  }
-
   render() {
-    let projects = () => {
-      let projects = this.state.projects;
-      return projects.map((project, index) =>         
-        <List.Item
-          as='a'
-          onClick={this.linkTo}
-          key={index}>
-          <Icon 
-            name="idea" />
+    const getProjects = () => {
+      const { projects } = this.props;
+      return projects.map(d => (
+        <List.Item key={d.project_id} >
+          <Icon name="idea" />
           <List.Content>
-            { project.project_name } - 
-            { project.point_of_contact }
+            <Link to={`/ideas/${d.project_id}`}>
+              { d.project_name } - { d.point_of_contact }
+            </Link>
           </List.Content>
         </List.Item>
-      );
-    }
+      ));
+    };
 
     return (
       <List
-        size='huge'
+        size="huge"
         divided
-        celled>
-        { projects() }
+        celled
+      >
+        { getProjects() }
       </List>
     );
   }
 }
+
+Projects.propTypes = {
+  projects: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
 
 export default Projects;


### PR DESCRIPTION
This PR does the following:

- Adds `.eslintrc` and `eslint-config-airbnb` for linting
- Moves the airtable ajax call to `App.js`, so it can be passed as a prop to both `Projects` and `Project`
- Refactors `Projects` to be stateless, renders the list of projects from props
- Adds `<Link>` to each idea in `Projects`, so they are clickable and will update the route
- `Project` now checks for its matching route param, then searches through the data to find the matching idea, and renders data from it.