### PR TITLE
Cw/8 add url slugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "react-dom": "^15.6.1",
     "react-router-dom": "^4.1.2",
     "react-scripts": "1.0.10",
-    "semantic-ui-react": "^0.71.1"
+    "semantic-ui-react": "^0.71.1",
+    "slug": "^0.9.1"
   },
   "scripts": {
     "start-js": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -3,10 +3,12 @@ import {
   BrowserRouter as Router,
   Route,
 } from 'react-router-dom';
+import Slug from 'slug';
 
 import Projects from './Projects';
 import Project from './Project';
-import IdeaCreate from './IdeaCreate'
+import IdeaCreate from './IdeaCreate';
+
 
 import './App.css';
 
@@ -33,6 +35,14 @@ class App extends Component {
       .then(response => response.json())
       .then((response) => {
         const projects = response.records.map(record => record.fields);
+
+        projects.forEach((project) => {
+          const d = project;
+          d.slug = Slug(d.project_name, { lower: true });
+        });
+
+        console.log(projects);
+
         this.setState({ projects });
       });
   }
@@ -50,7 +60,7 @@ class App extends Component {
             )}
           />
           <Route
-            path="/ideas/:id"
+            path="/ideas/:slug"
             render={props => (
               <Project projects={projects} {...props} />
             )}

--- a/src/Project.js
+++ b/src/Project.js
@@ -6,9 +6,9 @@ import DisqusThread from './DisqusThread';
 import './Project.css';
 
 const Project = (props) => {
-  const id = parseInt(props.match.params.id, 10);
+  const slug = props.match.params.slug;
 
-  const idea = props.projects.find(d => d.project_id === id);
+  const idea = props.projects.find(d => d.slug === slug);
 
   return (
     <div className="project">
@@ -19,7 +19,7 @@ const Project = (props) => {
             <DisqusThread
               id={idea.project_id.toString()}
               title={idea.project_name}
-              path={`/ideas/${idea.project_id}`}
+              path={`/ideas/${idea.slug}`}
             />
           </div>
         )
@@ -32,7 +32,7 @@ Project.propTypes = {
   projects: PropTypes.arrayOf(PropTypes.object).isRequired,
   match: PropTypes.shape({
     params: PropTypes.shape({
-      id: PropTypes.string,
+      slug: PropTypes.string,
     }),
   }).isRequired,
 };

--- a/src/Projects.js
+++ b/src/Projects.js
@@ -13,7 +13,7 @@ class Projects extends Component {
         <List.Item key={d.project_id} >
           <Icon name="idea" />
           <List.Content>
-            <Link to={`/ideas/${d.project_id}`}>
+            <Link to={`/ideas/${d.slug}`}>
               { d.project_name } - { d.point_of_contact }
             </Link>
           </List.Content>


### PR DESCRIPTION
This PR adds a slug to the airtable response, for use in generating links and building pretty URLs.  The corresponding components are all updated to use the slug instead of the id.