### PR TITLE
Disable TrackJS when developing locally

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -91,7 +91,7 @@
     </footer>
 
     <!-- BEGIN TRACKJS -->
-    <script type="text/javascript">window._trackJs = { token: '021d694d30524212979b729736656f55' };</script>
+    <script type="text/javascript">window._trackJs = { token: '021d694d30524212979b729736656f55', enabled: !(window.location.host.indexOf('localhost') >= 0) };</script>
     <script type="text/javascript" src="https://cdn.trackjs.com/releases/current/tracker.js"></script>
     <!-- END TRACKJS -->
   </body>


### PR DESCRIPTION
This solution simply checks if the window location host includes 'localhost'. 

Closes #46 