### PR TITLE
Implement scrolltotop on route change

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import Idea from './Idea';
 import IdeaCreate from './IdeaCreate';
 import Hero from './Hero';
 import Spinner from './Spinner';
+import ScrollToTop from './ScrollToTop';
 
 import './App.css';
 
@@ -65,10 +66,12 @@ class App extends Component {
     return (
       <div>
         <Router id={gaTrackingCode}>
-          <div className="App">
-            <Hero />
-            {content}
-          </div>
+          <ScrollToTop >
+            <div className="App">
+              <Hero />
+              {content}
+            </div>
+          </ScrollToTop>
         </Router>
       </div>
     );

--- a/src/ScrollToTop.js
+++ b/src/ScrollToTop.js
@@ -4,8 +4,6 @@ import PropTypes from 'prop-types';
 
 class ScrollToTop extends Component {
   componentDidUpdate(prevProps) {
-    console.log('Scroll did update', this.props.location, prevProps.location);
-
     if (this.props.location !== prevProps.location) {
       window.scrollTo(0, 0);
     }

--- a/src/ScrollToTop.js
+++ b/src/ScrollToTop.js
@@ -1,0 +1,24 @@
+import { Component } from 'react';
+import { withRouter } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
+class ScrollToTop extends Component {
+  componentDidUpdate(prevProps) {
+    console.log('Scroll did update', this.props.location, prevProps.location);
+
+    if (this.props.location !== prevProps.location) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+ScrollToTop.propTypes = {
+  location: PropTypes.shape().isRequired,
+  children: PropTypes.shape().isRequired,
+};
+
+export default withRouter(ScrollToTop);


### PR DESCRIPTION
This closes #44 by wrapping all child content of the `<Router/>` in a new `<ScrollToTop/> component that checks for new path and implements the scroll.