### PR TITLE
Add tag filtering

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -75,10 +75,24 @@ p, h1, h2, h3, h4, h5, h6 {
   }
 }
 
-.strategic-objectives, .tags {
+.filter--strategic-objectives,
+.filter--tags,
+.idea--tags {
   .button, .label {
     font-weight: $global-weight-bold;
     margin: 0 0.25rem 0.25rem 0;
+  }
+}
+.filter--tags {
+
+  .button {
+    @include button-style($label-background, auto, $label-color);
+
+    &.hollow {
+      @include button(false, $label-background, auto, $label-color, hollow);
+      font-size: 0.75rem;
+      margin: 0 0.25rem 0.25rem 0;
+    }
   }
 }
 

--- a/src/Idea.js
+++ b/src/Idea.js
@@ -16,6 +16,14 @@ const Idea = (props) => {
     <span key={d} className={`label ${slug(d)}`}>{d}</span>
   ));
 
+  const getTags = tags => tags.map(d => (
+    <span key={d} className={`label ${slug(d)}`}>{d}</span>
+  ));
+
+  const tags = idea && idea.tags && idea.tags.length > 0 ?
+    getTags(idea.tags) :
+    <div>None</div>;
+
   const objectives = idea && idea.strategic_objectives && idea.strategic_objectives.length > 0 ?
     getObjectives(idea.strategic_objectives) :
     <div>None</div>;
@@ -43,12 +51,8 @@ const Idea = (props) => {
                   <p className="strategic-objectives">{ objectives }</p>
                 </div>
                 <div className="callout">
-                  <h4 className="header-tiny">Project Type</h4>
-                  <p className="tags">
-                    <span className="label">Mapping</span>
-                    <span className="label">Data Explorer</span>
-                    <span className="label">Workflow</span>
-                  </p>
+                  <h4 className="header-tiny">Tags</h4>
+                  <p className="tags">{ tags }</p>
                 </div>
               </div>
               <div className="cell large-8">

--- a/src/Ideas.js
+++ b/src/Ideas.js
@@ -12,13 +12,8 @@ const allCategories = ['Economic Development', 'Data and Expertise', 'Resiliency
 
 const allValues = {};
 
-const checkIfAllSelected = (categories, all) => {
-  let allSelected = true;
-  all.forEach((d) => {
-    if (categories.indexOf(d) < 0) allSelected = false;
-  });
-  return allSelected;
-};
+const checkIfAllSelected = (categories, all) =>
+  all.every(current => categories.indexOf(current) > 0);
 
 // utility helpers for arrays
 const removeItem = (array, value) => {
@@ -43,7 +38,11 @@ class Ideas extends Component {
     const queryTags = query.get('tags') || '';
 
     allValues.categories = allCategories;
-    allValues.tags = unique(ideas.reduce((a, b) => a.concat(b.tags), []).filter(Boolean));
+    allValues.tags = unique(
+      ideas
+        .reduce((accumulator, element) => accumulator.concat(element.tags), [])
+        .filter(Boolean),
+    );
 
     const categories = queryCategories ? queryCategories.split(',') : allValues.categories;
     const tags = queryTags ? queryTags.split(',') : allValues.tags;
@@ -84,9 +83,10 @@ class Ideas extends Component {
 
     if (currentSelected.length === 0) currentSelected = all;
 
-    this.state[type] = currentSelected;
-    this.forceUpdate();
+    const stateObject = {};
+    stateObject[type] = currentSelected;
 
+    this.setState(stateObject);
     this.updateParams();
   }
 

--- a/src/Ideas.js
+++ b/src/Ideas.js
@@ -12,16 +12,16 @@ const defaultSelection = ['Economic Development', 'Data and Expertise', 'Resilie
 
 let allTags;
 
-function checkIfAllSelected(categories, all) {
+const checkIfAllSelected = (categories, all) => {
   let allSelected = true;
   all.forEach((d) => {
     if (categories.indexOf(d) < 0) allSelected = false;
   });
   return allSelected;
-}
+};
 
 // utility helpers for arrays
-function removeItem(array, value) {
+const removeItem = (array, value) => {
   const index = array.indexOf(value);
 
   if (index > -1) {
@@ -29,26 +29,27 @@ function removeItem(array, value) {
   }
 
   return array;
-}
+};
 
-function unique(array) {
-  return array.filter((x, i, a) => a.indexOf(x) === i);
-}
+const unique = array => array.filter((x, i, a) => a.indexOf(x) === i);
+
 
 class Ideas extends Component {
   constructor(props) {
     super();
     const { location, ideas } = props;
     const query = new URLSearchParams(location.search);
-    const value = query.get('categories') || '';
+    const queryCategories = query.get('categories') || '';
+    const queryTags = query.get('tags') || '';
 
-    const categories = value ? value.split(',') : defaultSelection;
+    const categories = queryCategories ? queryCategories.split(',') : defaultSelection;
 
     allTags = unique(ideas.reduce((a, b) => a.concat(b.tags), []).filter(Boolean));
+    const tags = queryTags ? queryTags.split(',') : allTags;
 
     this.state = {
       categories,
-      tags: allTags,
+      tags,
       search: '',
     };
   }
@@ -96,7 +97,7 @@ class Ideas extends Component {
 
     const paramChunks = [];
 
-    if (!checkIfAllSelected(categories, defaultSelection)) paramChunks.push(`catgories=${categories.join(',')}`);
+    if (!checkIfAllSelected(categories, defaultSelection)) paramChunks.push(`categories=${categories.join(',')}`);
     if (!checkIfAllSelected(tags, allTags)) paramChunks.push(`tags=${tags.join(',')}`);
 
     const search = (paramChunks.length === 0) ? '' : `?${paramChunks.join('&')}`;
@@ -188,7 +189,10 @@ class Ideas extends Component {
               </h3>
               <h4 className="header-small">{ d.customer }</h4>
               <p>{ d.short_description }</p>
-              <p className="tags">{ d.strategic_objectives && getObjectives(d.strategic_objectives) }</p>
+              <p className="tags">
+                { d.strategic_objectives && getObjectives(d.strategic_objectives) }
+                { d.tags && getTags(d.tags) }
+              </p>
             </div>
           </div>
         </div>

--- a/src/Ideas.js
+++ b/src/Ideas.js
@@ -160,7 +160,7 @@ class Ideas extends Component {
               </h3>
               <h4 className="header-small">{ d.customer }</h4>
               <p>{ d.short_description }</p>
-              <p className="tags">
+              <p className="idea--tags">
                 { d.strategic_objectives && getChips(d.strategic_objectives, 'categories') }
                 { d.tags && getChips(d.tags, 'tags') }
               </p>
@@ -180,13 +180,13 @@ class Ideas extends Component {
             <input type="text" value={this.state.search} onChange={this.changeSearch} />
             <div>
               <small>Filter by <a href="https://www1.nyc.gov/site/planning/about/dcp-priorities.page">DCP Strategic Objective</a>:</small>
-              <p className="strategic-objectives">
+              <p className="filter--strategic-objectives">
                 { getChips(allValues.categories, 'categories', true) }
               </p>
             </div>
             <div>
               <small>Filter by Tag</small>
-              <p className="strategic-objectives">
+              <p className="filter--tags">
                 { getChips(allValues.tags, 'tags', true) }
               </p>
             </div>


### PR DESCRIPTION
This PR:
- adds dynamic tags chips to the sidebar in `Idea`
- adds dynamic tag chips to the sidebar in `Ideas`
- allows the user to click on a Tag Chip to filter the Ideas
- manages the URL query params for both categories (strategic objectives) and tags

`Ideas.js` is cleaned up a bit by making a generic `getChips()` function that works with both categories and tags, and by making a generic `changeFilter()` function that handles chip click events.

Closes #36